### PR TITLE
fix(STONEINTG-840): update permissions of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/trigger-clair-db-build.yaml
+++ b/.github/workflows/trigger-clair-db-build.yaml
@@ -8,6 +8,9 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   SOURCE_BRANCH: main # building from main
 
@@ -21,7 +24,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: 'main'
-        token: ${{ secrets.HACBS_TEST_GITHUB_TOKEN }}
     - name: create empty commit
       run: |
           git config --global user.email "<>"


### PR DESCRIPTION
Now action misses username.

Instead of trying to provide 3rd party token, let's update permissions of default GITHUB_TOKEN, as we need it only for local repo.