### PR TITLE
feat: use updated clair-action/claircore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
-FROM quay.io/projectquay/clair-action:v0.0.8
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:adeedd50ce51475df1978b2da5ab1c0017f9596a5310fc54a26af285345ad7cf as build
+
+# For stability of the update process we need a newer version of claircore than
+# the version currently used in clair-action 0.0.9. The version 1.5.31 includes
+# a the needed fix from https://github.com/quay/claircore/pull/1410.
+
+RUN git clone --depth 1 --branch v0.0.9 https://github.com/quay/clair-action.git
+
+WORKDIR /opt/app-root/src/clair-action
+
+RUN go get github.com/quay/claircore@v1.5.31 && \
+    go build -o clair-action -trimpath ./cmd/cli
+
+FROM registry.access.redhat.com/ubi9-minimal@sha256:f182b500ff167918ca1010595311cf162464f3aa1cab755383d38be61b4d30aa
+
+COPY --from=build /opt/app-root/src/clair-action/clair-action /usr/bin/clair-action
 
 # Update the matcher database. Use the info log level to track sources
 RUN DB_PATH=/tmp/matcher.db /bin/clair-action --level info update


### PR DESCRIPTION
We have found[^1] that the Red Hat VEX[^2] data consistently contains the release date information, and the OVAL[^3] data consistently does not. Recently[^4] claircore introduced the Red Hat VEX updater and the clair-action was updated[^5] to use that version.

This updates to clair-action 0.0.9 which updates claircore to 1.5.30 containing the needed Red Hat VEX support.

Resolves: https://issues.redhat.com/browse/EC-835

[^1]: https://issues.redhat.com/browse/EC-812
[^2]: https://www.redhat.com/en/blog/red-hat-vex-files-cves-are-now-generally-available
[^3]: https://access.redhat.com/articles/221883/
[^4]: https://issues.redhat.com/browse/CLAIRDEV-28
[^5]: https://issues.redhat.com/browse/EC-854