### PR TITLE
fix: use buildah-1-8-0 clusterTask for builds

### DIFF
--- a/.tekton/build_and_trigger.yaml
+++ b/.tekton/build_and_trigger.yaml
@@ -115,7 +115,7 @@ spec:
         runAfter:
           - calculate-tag
         taskRef:
-          name: buildah
+          name: buildah-1-8-0
           kind: ClusterTask
         params:
           - name: IMAGE


### PR DESCRIPTION
Use the `buildah-1-8-0` clusterTask in the `build_and_trigger` Tekton pipeline.

This should resolve the issue where the `buildah` clusterTask is missing:
```
 Pipeline tekton-ci/clair-in-ci-db-build-and-trigger-p56pq can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "buildah": clustertasks.tekton.dev "buildah" not found 
```