### PR TITLE
chore(stoneintg-1134): update github workflows to ubuntu-24.04

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   lint:
     name: Lint change content
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/trigger-clair-db-build.yaml
+++ b/.github/workflows/trigger-clair-db-build.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   test:
     name: Build the new image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out repository code


### PR DESCRIPTION
The ubuntu-20.04 image for github actions is being deprecated. Workflows that still rely on the image after April 1, 2025 will no longer work. We need to update to ubuntu-24.04 to avoid this.